### PR TITLE
Fix: Create directory if missing when saving configuration

### DIFF
--- a/Misc/FileUtils.cs
+++ b/Misc/FileUtils.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.IO;
+
+namespace BetterRaid.Misc;
+
+internal static class FileUtils
+{
+    public static void EnsureDirectoryExists(string directoryPath)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath))
+            throw new ArgumentException("Directory path cannot be null or empty.", nameof(directoryPath));
+
+        if (Path.HasExtension(directoryPath))
+            directoryPath = Path.GetDirectoryName(directoryPath) ?? throw new ArgumentNullException(nameof(directoryPath));
+        
+        if (!Directory.Exists(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+    }
+}

--- a/Services/DatabaseService.cs
+++ b/Services/DatabaseService.cs
@@ -163,6 +163,7 @@ public class DatabaseService : IDatabaseService, INotifyPropertyChanged
         var dbStr = JsonConvert.SerializeObject(Database, Formatting.Indented);
         var targetPath = _databaseFilePath!;
 
+        FileUtils.EnsureDirectoryExists(targetPath);
         File.WriteAllText(targetPath, dbStr);
 
         _logger.LogDebug("Saved database to {targetPath}", targetPath);


### PR DESCRIPTION
Hi,
I've been using BetterRaid and made a small fix to ensure the configuration folder is created if it’s missing.
Hope you’re doing well! Haven’t seen you online in a while.